### PR TITLE
adds toml to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 yapf
+toml


### PR DESCRIPTION
This is necessary to allow this action to work with projects that have a `pyproject.toml` at their root.

Should resolve #30 